### PR TITLE
adds archival note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# This repository is superseded by the work at ToIP Technical Stack Working Group ACDC Task Force
+
+https://github.com/trustoverip/tswg-acdc-specification
+
 # Public Transaction Event Logs (PTEL)
 
 This is the working area for the individual Internet-Draft, "Public Transaction Event Logs (PTEL)".

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # This repository is superseded by the work at ToIP Technical Stack Working Group ACDC Task Force
 
-https://github.com/trustoverip/tswg-acdc-specification
+https://github.com/trustoverip/tswg-ptel-specification
 
 # Public Transaction Event Logs (PTEL)
 


### PR DESCRIPTION
Due to the proposed move to the Trust over IP Foundation, we should archive this repository.